### PR TITLE
fw/b: Allow adb over network when any default network is active

### DIFF
--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -2,7 +2,7 @@
 <!--
 /**
  * Copyright (c) 2015, The CyanogenMod Project
- * Copyright (c) 2017-2018, The LineageOS Project
+ * Copyright (c) 2017-2019, The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@
     <!-- Custom QS tiles -->
     <!-- ADB over network QS tile -->
     <string name="quick_settings_network_adb_label">ADB over network</string>
+    <string name="quick_settings_network_adb_no_network">no network</string>
 
     <!-- Ambient display QS tile -->
     <string name="quick_settings_ambient_display_label">Ambient display</string>


### PR DESCRIPTION
* Track the android default network instead of wifi state.

* If on, always allow toggle off regardless of whether the
  network disappears on you.

* When toggled on and network has gone show "no network"
  in place of the local link address.

Change-Id: Ib8ee1b5334ed7409319f79716047b438a7bface8