### PR TITLE
Allow tuning of heaptargetutilization

### DIFF
--- a/core/java/com/android/internal/os/RuntimeInit.java
+++ b/core/java/com/android/internal/os/RuntimeInit.java
@@ -28,6 +28,7 @@ import android.os.SystemProperties;
 import android.os.Trace;
 import android.util.Log;
 import android.util.Slog;
+
 import com.android.internal.logging.AndroidConfig;
 import com.android.server.NetworkManagementSocketTagger;
 import dalvik.system.VMRuntime;
@@ -351,9 +352,6 @@ public class RuntimeInit {
         // leftover running threads to crash before the process actually exits.
         nativeSetExitWithoutCleanup(true);
 
-        // We want to be fairly aggressive about heap utilization, to avoid
-        // holding on to a lot of memory that isn't needed.
-        VMRuntime.getRuntime().setTargetHeapUtilization(0.75f);
         VMRuntime.getRuntime().setTargetSdkVersion(targetSdkVersion);
 
         final Arguments args = new Arguments(argv);

--- a/services/java/com/android/server/SystemServer.java
+++ b/services/java/com/android/server/SystemServer.java
@@ -395,10 +395,6 @@ public final class SystemServer {
             // Mmmmmm... more memory!
             VMRuntime.getRuntime().clearGrowthLimit();
 
-            // The system server has to run all of the time, so it needs to be
-            // as efficient as possible with its memory usage.
-            VMRuntime.getRuntime().setTargetHeapUtilization(0.8f);
-
             // Some devices rely on runtime fingerprint generation, so make sure
             // we've defined it before booting further.
             Build.ensureFingerprintProperty();


### PR DESCRIPTION
Remove a pair of explicit sets of this value.  This allows ART to tune
this parameter to improve GC responsiveness and memory usage.  Tuning
this parameter is a key area of work for OEM-requested high-memory
device configurations.

Bug: 145823510
Test: boot and run with various configurations of the flag.
Change-Id: I19680ff5fa1ebf9dfd4a3f71533d03510f4da414
Merged-In: I19680ff5fa1ebf9dfd4a3f71533d03510f4da414
(cherry picked from commit b2910d3b6ff282194a4fa4e6c6818c4325168a4f)